### PR TITLE
device stats not working with HTTP

### DIFF
--- a/src/device-stats.es6.js
+++ b/src/device-stats.es6.js
@@ -25,7 +25,8 @@ export default function(RED) {
           if (this.useString || opts && opts.useString) {
             stats = JSON.stringify(stats);
           }
-          this.send({ payload: stats });
+          msg.payload = stats;
+          this.send(msg);
           this.timeout = setTimeout(() => {
             if (this.timeout) {
               this.status({});


### PR DESCRIPTION
Because it deletes all attributes from message instead of only replacing the payload.